### PR TITLE
no web3, no babel

### DIFF
--- a/lib/dapp-scratch.js
+++ b/lib/dapp-scratch.js
@@ -1,7 +1,7 @@
 "use strict"
 const fs = require('fs-extra')
 var colors = require('colors')
-const web3Eth = require('web3-eth')
+// const web3Eth = require('web3-eth')
 class DappScratch {
 
     constructor ({contractPath, abiPath, skip}) {
@@ -128,16 +128,18 @@ class DappScratch {
             resolve()
           })
         } else if (this.contractPath) {
+          reject(new Error('Sorry compiling the contract into an ABI hasn\'t been implemented yet'))
           // compile abi from contract
-          fs.readFile(this.contractPath, 'utf8', (err, data) => {
-            if (err) reject(new Error(err))
-            web3Eth.compile.solidity(data).then((response) => {
-              this.abi = response.info.abiDefinition
-              resolve()
-            }).catch((err) => {
-              reject(new Error(err))
-            })
-          })
+          // todo
+          // fs.readFile(this.contractPath, 'utf8', (err, data) => {
+          //   if (err) reject(new Error(err))
+          //   web3Eth.compile.solidity(data).then((response) => {
+          //     this.abi = response.info.abiDefinition
+          //     resolve()
+          //   }).catch((err) => {
+          //     reject(new Error(err))
+          //   })
+          // })
         } else {
           reject(new Error('No ABI or Contract'))
         }

--- a/package.json
+++ b/package.json
@@ -12,26 +12,11 @@
     "commander": "^2.11.0",
     "fs-extra": "^4.0.2",
     "inquirer": "^4.0.0",
-    "shelljs": "^0.7.8",
-    "web3-eth": "^1.0.0-beta.24"
+    "shelljs": "^0.7.8"
   },
   "devDependencies": {
-    "babel-cli": "^6.26.0",
-    "babel-core": "^6.26.0",
-    "babel-polyfill": "^6.26.0",
-    "babel-preset-env": "^1.6.1",
-    "babel-preset-es2015": "^6.24.1",
-    "babel-register": "^6.26.0",
-    "eslint": "^4.10.0",
-    "eslint-config-airbnb-base": "^12.1.0",
-    "eslint-plugin-import": "^2.8.0",
-    "eslint-watch": "^3.1.3",
-    "i": "^0.3.6",
-    "mocha": "^4.0.1"
   },
   "scripts": {
-    "dev": "esw -w ./assets",
-    "build": "babel assets/sample.js -d lib",
-    "test": "mocha  --exit --compilers js:babel-core/register"
+
   }
 }


### PR DESCRIPTION
to avoid lengthy unnecessary npm install and node-gyp.
might need to add back in future versions that include testing a pre-compiled builds