### PR TITLE
Refactorization to manage multiple contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+dapp-scratch-wrapper

--- a/lib/contracts/index.js
+++ b/lib/contracts/index.js
@@ -1,0 +1,14 @@
+/**
+ * The file enables `/dapp-scratch-wrapper/index.js` to import all contract modules
+ * in a one-shot manner. There should not be any reason to edit this file.
+ */
+
+const files = require.context('.', false, /\.js$/)
+const modules = {}
+
+files.keys().forEach(key => {
+  if (key === './index.js') return
+  modules[key.replace(/(\.\/|\.js)/g, '')] = files(key).default
+})
+
+export default modules

--- a/lib/dapp-scratch.js
+++ b/lib/dapp-scratch.js
@@ -67,7 +67,8 @@ class DappScratch {
         .then(this.wrapperReplaceName.bind(this))
         .then(this.buildFunctions.bind(this))
         .then(this.writeWrapper.bind(this))
-        .then(resolve)
+        .then(this.copyStaticFiles.bind(this))
+        // .then(resolve)
         .catch((err) => {
           reject(new Error(err))
         })
@@ -94,10 +95,8 @@ class DappScratch {
 
     writeWrapper () {
       return new Promise((resolve, reject) => {
-        if (fs.existsSync('./dapp-scratch-wrapper')) fs.removeSync('./dapp-scratch-wrapper')
-        fs.mkdirSync('./dapp-scratch-wrapper')
-        fs.mkdirSync('./dapp-scratch-wrapper/' + this.projectName)
-        this.path = './dapp-scratch-wrapper/' + this.projectName + '/index.js'
+        fs.mkdirsSync('./dapp-scratch-wrapper/contracts')
+        this.path = `./dapp-scratch-wrapper/contracts/${this.projectName}.js`
         fs.writeFile(this.path, this.wrapperFile, (err) => {
           if (err) {
             reject(new Error(err))
@@ -108,6 +107,13 @@ class DappScratch {
       })
     }
 
+    copyStaticFiles () {
+      return new Promise((resolve, reject) => {
+        fs.copySync(`${__dirname}/index.js`, './dapp-scratch-wrapper/index.js')
+        fs.copySync(`${__dirname}/contracts/index.js`, './dapp-scratch-wrapper/contracts/index.js')
+        resolve()
+      })
+    }
 
 
     getAbi () {
@@ -248,7 +254,7 @@ class DappScratch {
             all += functions + ') {\n'
 
             if (info.stateMutability === 'nonpayable') {
-              all += '    if (!this.account) return new Error(\'Unlock Wallet\')\n'
+              all += '    if (!this.contractManager.account) return new Error(\'Unlock Wallet\')\n'
             }
 
             all += '    return this.' + this.projectName + '.methods.' + info.name + '(' + typedFunctions + ')'
@@ -257,7 +263,7 @@ class DappScratch {
                 all += '.call()\n'
                 break
               case('nonpayable'):
-                all += '.send({from: this.account})\n'
+                all += '.send({from: this.contractManager.account})\n'
                 all += '    .on(\'transactionHash\', (hash) => {\n'
                 all += '      console.log(hash)\n'
                 all += '      this.loading = true\n'

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,8 @@ class ContractManager {
       autoInit: true,
       connectionRetries: 3
     }
+    this.identityObservers = []
+
     Object.assign(this.options, options)
     if (this.options.autoInit) this.initWeb3()
   }
@@ -124,6 +126,11 @@ class ContractManager {
       if (accounts.length && this.account !== accounts[0]) {
         this.unlocked = true
         this.account = accounts[0]
+
+        for (let i in this.identityObservers) {
+          this.identityObservers[i](this.account)
+        }
+
       } else if (!accounts.length) {
         this.unlocked = false
         this.account = null
@@ -140,6 +147,13 @@ class ContractManager {
     return new Promise((resolve, reject) => {
       resolve()
     })
+  }
+
+  addIdentityObserver (observer) {
+    this.identityObservers.push(observer)
+    if (this.address) {
+      observer(this.account)
+    }
   }
 
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,147 @@
+
+import Web3 from 'web3'
+const BN = Web3.utils.BN
+import ZeroClientProvider from 'web3-provider-engine/zero.js'
+import IdManagerProvider from '@aeternity/id-manager-provider'
+import contracts from './contracts'
+
+class ContractManager {
+  constructor (options) {
+    this.pollingInterval = null
+    this.account = null
+    this.unlocked = false
+    this.balanceWei = 0
+    this.balance = 0
+    this.genesisBlock = 0
+    this.loading = false
+    this.options = {
+      autoInit: true,
+      connectionRetries: 3
+    }
+    Object.assign(this.options, options)
+    if (this.options.autoInit) this.initWeb3()
+  }
+
+  /*
+   * Connect
+   */
+
+  initWeb3 () {
+    return new Promise((resolve, reject) => {
+
+      let web3Provider = false
+      let idManager = new IdManagerProvider({
+        rpcUrl: 'http://localhost:9545',
+        skipSecurity: true,
+
+      })
+
+      idManager.checkIdManager().then((idManagerPresent)=>{
+        // check for aedentity app
+        if (idManagerPresent) {
+          web3Provider = idManager.web3.currentProvider
+
+          // check for metamask
+        } else if (global.web3) {
+          web3Provider = web3.currentProvider
+
+          // attempt to try again if no aedentity app or metamask
+        } else if (this.options.connectionRetries > 0){
+          this.options.connectionRetries -= 1
+          setTimeout(() => {
+            this.initWeb3().then(resolve).catch((error) => {
+              reject(new Error(error))
+            })
+          }, 1000)
+          // revert to a read only version using infura endpoint
+        } else {
+          this.readOnly = true
+          web3Provider = ZeroClientProvider({
+            getAccounts: function(){},
+            rpcUrl: 'https://mainnet.infura.io',
+            // rpcUrl: 'https://testnet.infura.io',
+            // rpcUrl: 'https://rinkeby.infura.io',
+            // rpcUrl: 'https://kovan.infura.io',
+          })
+        }
+
+        if (web3Provider) {
+          global.web3 = new Web3(web3Provider)
+          this.startChecking()
+
+          if (this.options.getPastEvents) this.getPastEvents()
+          if (this.options.watchFutureEvents) this.watchFutureEvents()
+        }
+      })
+    })
+  }
+
+  /*
+   * Check every second for switching network or wallet
+   */
+
+  startChecking () {
+    if (this.pollingInterval) clearInterval(this.pollingInterval)
+    this.getGenesisBlock()
+      .then(() => {
+        this.pollingInterval = setInterval(this.check.bind(this), 1000)
+      })
+      .catch((err) => {
+        throw new Error(err)
+      })
+  }
+
+  check () {
+    this.checkNetwork()
+      .then(this.checkAccount.bind(this))
+      .catch((error) => {
+        console.error(error)
+        throw new Error(error)
+      })
+  }
+
+  checkNetwork () {
+    return global.web3.eth.net.getId((err, netId) => {
+      if (err) console.error(err)
+      if (!err && this.network !== netId) {
+        this.network = netId
+        return this.deployContracts()
+      }
+    })
+  }
+
+  deployContracts () {
+    for (const contract in contracts) {
+      if (contracts.hasOwnProperty(contract)) {
+        this[contract] = new contracts[contract](this)
+      }
+    }
+  }
+
+  checkAccount () {
+    return global.web3.eth.getAccounts((error, accounts) => {
+      if (error) throw new Error(error)
+      if (accounts.length && this.account !== accounts[0]) {
+        this.unlocked = true
+        this.account = accounts[0]
+      } else if (!accounts.length) {
+        this.unlocked = false
+        this.account = null
+      }
+    })
+  }
+
+
+  /*
+   * Not Yet Implemented vvvv
+   */
+
+  getGenesisBlock () {
+    return new Promise((resolve, reject) => {
+      resolve()
+    })
+  }
+
+}
+
+export default ContractManager

--- a/lib/starterTemplate.js
+++ b/lib/starterTemplate.js
@@ -4,7 +4,6 @@ class __NAME__ {
 
     this.contractManager = contractManager
     this.address = __ADDRESS__
-    this.genesisBlock = 0
     this.options = {
       getPastEvents: false,
       watchFutureEvents: false
@@ -24,12 +23,6 @@ class __NAME__ {
   /*
    * Not Yet Implemented vvvv
    */
-
-  getGenesisBlock () {
-    return new Promise((resolve, reject) => {
-      resolve()
-    })
-  }
 
   getPastEvents () {
     return new Promise((resolve, reject) => {

--- a/lib/starterTemplate.js
+++ b/lib/starterTemplate.js
@@ -7,135 +7,26 @@ import ZeroClientProvider from 'web3-provider-engine/zero.js'
 import IdManagerProvider from '@aeternity/id-manager-provider'
 
 class __NAME__ {
-  constructor (options) {
+  constructor (contractManager, options) {
 
-    this.__NAME__ = null
-
-    this.pollingInterval = null
-    this.account = null
-    this.unlocked = false
-    this.balanceWei = 0
-    this.balance = 0
+    this.contractManager = contractManager
     this.address = __ADDRESS__
     this.genesisBlock = 0
-    this.loading = false
     this.options = {
-      autoInit: true,
       getPastEvents: false,
-      watchFutureEvents: false,
-      connectionRetries: 3
+      watchFutureEvents: false
     }
     Object.assign(this.options, options)
-    if (this.options.autoInit) this.initWeb3()
+
+    if (!this.address || this.address === 'REPLACE_WITH_CONTRACT_ADDRESS') return new Error('Please provide a contract address')
+    this.__NAME__ = new global.web3.eth.Contract(__NAME__Artifacts.abi, this.address)
+
   }
 
   // hello world : )
   helloWorld () {
     console.log('hello world!')
   }
-
-  /*
-   * Connect
-   */
-
-  initWeb3 () {
-    return new Promise((resolve, reject) => {
-
-      let web3Provider = false
-      let idManager = new IdManagerProvider()
-
-      idManager.checkIdManager().then((idManagerPresent)=>{
-				// check for aedentity app
-        if (idManagerPresent) {
-          web3Provider = idManager.web3.currentProvider
-
-          // check for metamask
-        } else if (global.web3) {
-          web3Provider = web3.currentProvider
-
-          // attempt to try again if no aedentity app or metamask
-        } else if (this.options.connectionRetries > 0){
-          this.options.connectionRetries -= 1
-          setTimeout(() => {
-            this.initWeb3().then(resolve).catch((error) => {
-              reject(new Error(error))
-            })
-          }, 1000)
-          // revert to a read only version using infura endpoint
-        } else {
-          this.readOnly = true
-          web3Provider = ZeroClientProvider({
-            getAccounts: function(){},
-            rpcUrl: 'https://mainnet.infura.io',
-            // rpcUrl: 'https://testnet.infura.io',
-            // rpcUrl: 'https://rinkeby.infura.io',
-            // rpcUrl: 'https://kovan.infura.io',
-          })
-        }
-
-        if (web3Provider) {
-          global.web3 = new Web3(web3Provider)
-          this.startChecking()
-
-          if (this.options.getPastEvents) this.getPastEvents()
-          if (this.options.watchFutureEvents) this.watchFutureEvents()
-        }
-      })
-    })
-  }
-
-  /*
-   * Check every second for switching network or wallet
-   */
-
-  startChecking () {
-    if (this.pollingInterval) clearInterval(this.pollingInterval)
-    this.getGenesisBlock()
-    .then(() => {
-      this.pollingInterval = setInterval(this.check.bind(this), 1000)
-    })
-    .catch((err) => {
-      throw new Error(err)
-    })
-  }
-
-  check () {
-    this.checkNetwork()
-    .then(this.checkAccount.bind(this))
-    .catch((error) => {
-      console.error(error)
-      throw new Error(error)
-    })
-  }
-
-  checkNetwork () {
-    return global.web3.eth.net.getId((err, netId) => {
-      if (err) console.error(err)
-      if (!err && this.network !== netId) {
-        this.network = netId
-        return this.deployContract()
-      }
-    })
-  }
-
-  deployContract () {
-    if (!this.address || this.address === 'REPLACE_WITH_CONTRACT_ADDRESS') return new Error('Please provide a contract address')
-    this.__NAME__ = new global.web3.eth.Contract(__NAME__Artifacts.abi, this.address)
-  }
-
-  checkAccount () {
-    return global.web3.eth.getAccounts((error, accounts) => {
-      if (error) throw new Error(error)
-      if (accounts.length && this.account !== accounts[0]) {
-        this.unlocked = true
-        this.account = accounts[0]
-      } else if (!accounts.length) {
-        this.unlocked = false
-        this.account = null
-      }
-    })
-  }
-
 
   /*
    * Not Yet Implemented vvvv

--- a/lib/starterTemplate.js
+++ b/lib/starterTemplate.js
@@ -1,11 +1,4 @@
 
-import __NAME__Artifacts from '../../build/contracts/__NAME__.json'
-
-import Web3 from 'web3'
-const BN = Web3.utils.BN
-import ZeroClientProvider from 'web3-provider-engine/zero.js'
-import IdManagerProvider from '@aeternity/id-manager-provider'
-
 class __NAME__ {
   constructor (contractManager, options) {
 

--- a/package.json
+++ b/package.json
@@ -8,15 +8,15 @@
   "author": "Billy Rennekamp &lt;hello@okw.me&gt;",
   "license": "ISC",
   "dependencies": {
+    "@aeternity/id-manager-provider": "github:aeternity/id-manager-provider",
     "colors": "^1.1.2",
     "commander": "^2.11.0",
     "fs-extra": "^4.0.2",
     "inquirer": "^4.0.0",
     "shelljs": "^0.7.8"
   },
-  "devDependencies": {
-  },
+  "devDependencies": {},
   "scripts": {
-
+    "dev": "node bin/dapp-scratch.js"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "author": "Billy Rennekamp &lt;hello@okw.me&gt;",
   "license": "ISC",
   "dependencies": {
-    "@aeternity/id-manager-provider": "github:aeternity/id-manager-provider",
     "colors": "^1.1.2",
     "commander": "^2.11.0",
     "fs-extra": "^4.0.2",


### PR DESCRIPTION
During the playground phase of my contribution for the Aeternity hackathon, I found myself with two contracts soon. I realised, that the current CLI only generated a javascript contract wrapper at a time, overwriting the last generation.

This could be easily fixed by removing the line in `DappScratch.writeWrapper` which deleted the old `dapp-scratch-wrapper` folder, but I also found, that having more than one contract, the initialisation part for `web3` and the account initialisation should not be part of the contract wrapper class in a scenario that manages more than one contract, so I separated the contracts from the initialisation part and introduced a manager class, that manages the account related initialisation and instantiates the contracts.